### PR TITLE
Enable type safe project accessors on Gradle Settings

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,6 +19,8 @@ dependencyResolutionManagement {
     }
 }
 
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
+
 rootProject.name = "travelin-android"
 include(":app")
 include(":auth:data")


### PR DESCRIPTION
Enable type safe project accessors so imports between modules, instead of using "hardcoded string" so imports can look like this:

![image](https://github.com/user-attachments/assets/11370b86-d542-4971-af03-e7f587bda997)
