### PR TITLE
Disable dynamicColor by default

### DIFF
--- a/core/presentation/designsystem/src/main/java/com/projectlab/core/presentation/designsystem/theme/Theme.kt
+++ b/core/presentation/designsystem/src/main/java/com/projectlab/core/presentation/designsystem/theme/Theme.kt
@@ -105,7 +105,7 @@ val unspecified_scheme = ColorFamily(
 fun TravelinTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     // Dynamic color is available on Android 12+
-    dynamicColor: Boolean = true,
+    dynamicColor: Boolean = false,
     content: @Composable() () -> Unit
 ) {
     val colorScheme = when {


### PR DESCRIPTION
In order to preserve the intended colors for our theme, we should disable dynamicColor by default in TravelinTheme

Disabled, expected color:
![image](https://github.com/user-attachments/assets/05c5df94-edad-4ad5-bc5f-a903f934daa7)

Enabled, color is changed:
![image](https://github.com/user-attachments/assets/529499b7-924e-4bca-8cef-356fd15c438c)
