### PR TITLE
feat: implement location permission request

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+
     <application
         android:name=".TravelinApp"
         android:allowBackup="true"

--- a/core/presentation/ui/build.gradle.kts
+++ b/core/presentation/ui/build.gradle.kts
@@ -1,10 +1,13 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+
+    // Compose
+    alias(libs.plugins.compose.compiler)
 }
 
 android {
-    namespace = "com.projectlab.presentation.ui"
+    namespace = "com.projectlab.core.presentation.ui"
     compileSdk = 35
 
     defaultConfig {
@@ -23,6 +26,14 @@ android {
             )
         }
     }
+
+    buildFeatures {
+        compose = true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.14"
+    }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
@@ -37,6 +48,17 @@ dependencies {
     // Core
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
+
+    // UI
+    implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.runtime.android)
+    implementation(libs.androidx.compose.ui)
+    implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.material3.android)
+
+    // Core System
+    implementation(projects.core.presentation.designsystem)
+    implementation(libs.ui.tooling.preview.android)
 
     // Testing
     testImplementation(libs.junit)

--- a/core/presentation/ui/src/main/java/com/projectlab/core/presentation/ui/components/BottomLocationBar.kt
+++ b/core/presentation/ui/src/main/java/com/projectlab/core/presentation/ui/components/BottomLocationBar.kt
@@ -1,0 +1,46 @@
+package com.projectlab.core.presentation.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import com.projectlab.core.presentation.designsystem.ButtonPrimary
+import com.projectlab.core.presentation.designsystem.theme.TravelinTheme
+import com.projectlab.core.presentation.ui.R
+
+@Composable
+fun BottomLocationBar(
+    onGetLocation: () -> Unit,
+) {
+    TravelinTheme(dynamicColor = false, darkTheme = false) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.tertiaryContainer)
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                stringResource(id = R.string.results_near_you),
+                style = MaterialTheme.typography.titleMedium
+            )
+            ButtonPrimary(
+                onClick = onGetLocation,
+                text = stringResource(id = R.string.get_location),
+                fullWidth = false,
+                modifier = Modifier.semantics { contentDescription = "Give Location Permission" }
+            )
+        }
+    }
+}

--- a/core/presentation/ui/src/main/java/com/projectlab/core/presentation/ui/components/CenterLocationPrompt.kt
+++ b/core/presentation/ui/src/main/java/com/projectlab/core/presentation/ui/components/CenterLocationPrompt.kt
@@ -1,0 +1,58 @@
+package com.projectlab.core.presentation.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import com.projectlab.core.presentation.designsystem.ButtonPrimary
+import com.projectlab.core.presentation.designsystem.ButtonSecondary
+import com.projectlab.core.presentation.designsystem.theme.TravelinTheme
+import com.projectlab.core.presentation.designsystem.theme.spacing
+import com.projectlab.core.presentation.ui.R
+
+@Composable
+fun CenterLocationPrompt(
+    onGetLocation: () -> Unit,
+    onReject: () -> Unit
+) {
+    TravelinTheme(dynamicColor = false, darkTheme = false) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                stringResource(R.string.location_not_available),
+                style = MaterialTheme.typography.titleLarge
+            )
+            Row(modifier = Modifier.padding(top = MaterialTheme.spacing.medium)) {
+                ButtonPrimary(
+                    onClick = onGetLocation,
+                    text = stringResource(R.string.get_location),
+                    fullWidth = false,
+                    modifier = Modifier.semantics {
+                        contentDescription = "Give Location Permission"
+                    })
+                Spacer(modifier = Modifier.padding(MaterialTheme.spacing.medium))
+                ButtonSecondary(
+                    onClick = onReject,
+                    text = stringResource(R.string.no_thanks),
+                    fullWidth = false,
+                    modifier = Modifier.semantics {
+                        contentDescription = "Reject Location Permission"
+                    })
+            }
+        }
+    }
+}

--- a/core/presentation/ui/src/main/java/com/projectlab/core/presentation/ui/components/LocationPermissionComponent.kt
+++ b/core/presentation/ui/src/main/java/com/projectlab/core/presentation/ui/components/LocationPermissionComponent.kt
@@ -1,0 +1,80 @@
+package com.projectlab.core.presentation.ui.components
+
+import android.Manifest
+import android.app.Activity
+import android.content.Context
+import android.widget.Toast
+import androidx.compose.runtime.Composable
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.core.app.ActivityCompat
+import com.projectlab.core.presentation.ui.R
+import com.projectlab.core.presentation.ui.model.LocationPermissionState
+import com.projectlab.core.presentation.ui.utils.LocationUtils
+
+@Composable
+fun LocationPermissionComponent(
+    locationUtils: LocationUtils,
+    context: Context,
+    isBottomBar: Boolean = false,
+    onPermissionGranted: () -> Unit,
+    onPermissionRejected: () -> Unit,
+) {
+    val permissionState = remember { mutableStateOf(LocationPermissionState.NOT_REQUESTED) }
+
+    val requestPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestMultiplePermissions()
+    ) { permissions ->
+        if (
+            permissions[Manifest.permission.ACCESS_FINE_LOCATION] == true &&
+            permissions[Manifest.permission.ACCESS_COARSE_LOCATION] == true
+        ) {
+            permissionState.value = LocationPermissionState.GRANTED
+            onPermissionGranted()
+        } else {
+            val rationaleRequired = ActivityCompat.shouldShowRequestPermissionRationale(
+                context as Activity,
+                Manifest.permission.ACCESS_FINE_LOCATION
+            ) || ActivityCompat.shouldShowRequestPermissionRationale(
+                context,
+                Manifest.permission.ACCESS_COARSE_LOCATION
+            )
+
+            permissionState.value = LocationPermissionState.DENIED
+
+            if (rationaleRequired) {
+                Toast.makeText(context, context.getString(R.string.location_permission_required), Toast.LENGTH_SHORT).show()
+            } else {
+                Toast.makeText(context, context.getString(R.string.permission_denied_enable), Toast.LENGTH_SHORT).show()
+            }
+
+            onPermissionRejected()
+        }
+    }
+
+    if (isBottomBar) {
+        BottomLocationBar(
+            onGetLocation = {
+                requestPermissionLauncher.launch(arrayOf(
+                    Manifest.permission.ACCESS_FINE_LOCATION,
+                    Manifest.permission.ACCESS_COARSE_LOCATION
+                ))
+            },
+        )
+    } else {
+        CenterLocationPrompt(
+            onGetLocation = {
+                requestPermissionLauncher.launch(arrayOf(
+                    Manifest.permission.ACCESS_FINE_LOCATION,
+                    Manifest.permission.ACCESS_COARSE_LOCATION
+                ))
+            },
+            onReject = {
+                permissionState.value = LocationPermissionState.DENIED
+                onPermissionRejected()
+            }
+        )
+    }
+}

--- a/core/presentation/ui/src/main/java/com/projectlab/core/presentation/ui/model/LocationPermissionState.kt
+++ b/core/presentation/ui/src/main/java/com/projectlab/core/presentation/ui/model/LocationPermissionState.kt
@@ -1,0 +1,7 @@
+package com.projectlab.core.presentation.ui.model
+
+enum class LocationPermissionState {
+    NOT_REQUESTED,
+    GRANTED,
+    DENIED
+}

--- a/core/presentation/ui/src/main/java/com/projectlab/core/presentation/ui/utils/LocationUtils.kt
+++ b/core/presentation/ui/src/main/java/com/projectlab/core/presentation/ui/utils/LocationUtils.kt
@@ -1,0 +1,22 @@
+package com.projectlab.core.presentation.ui.utils
+
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.core.content.ContextCompat
+
+class LocationUtils(val context: Context) {
+
+    fun hasLocationPermission(context: Context): Boolean {
+        return ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.ACCESS_FINE_LOCATION
+        ) == PackageManager.PERMISSION_GRANTED
+                &&
+                ContextCompat.checkSelfPermission(
+                    context,
+                    Manifest.permission.ACCESS_COARSE_LOCATION
+                ) == PackageManager.PERMISSION_GRANTED
+    }
+}

--- a/core/presentation/ui/src/main/res/values-es/strings.xml
+++ b/core/presentation/ui/src/main/res/values-es/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="results_near_you">Resultados cerca de ti</string>
+    <string name="get_location">Obtener ubicación</string>
+    <string name="no_thanks">No, gracias</string>
+    <string name="location_not_available">Ubicación no disponible</string>
+    <string name="location_permission_required">Permisos de ubicación requeridos</string>
+    <string name="permission_denied_enable">Permiso denegado. Modificar en las configuraciones.</string>
+</resources>

--- a/core/presentation/ui/src/main/res/values/strings.xml
+++ b/core/presentation/ui/src/main/res/values/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="results_near_you">Results near you</string>
+    <string name="get_location">Get Location</string>
+    <string name="no_thanks">No, thanks</string>
+    <string name="location_not_available">Location not available</string>
+    <string name="location_permission_required">Location permission required</string>
+    <string name="permission_denied_enable">Permission denied. Enable it in settings.</string>
+</resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,8 @@ daggerHilt = "2.56.1"
 androidGradlePlugin = "8.8.2"
 androidTools = "31.9.2"
 uiTestJunit4 = "<version>"
+material3Android = "1.3.2"
+uiToolingPreviewAndroid = "1.8.0"
 
 [libraries]
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradlePlugin" }
@@ -58,6 +60,8 @@ firebase = { group = "com.google.firebase", name = "firebase-bom", version.ref =
 firebase-auth-ktx = { group = "com.google.firebase", name = "firebase-auth-ktx" }
 kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 ksp-gradlePlugin = { group = "com.google.devtools.ksp", name = "com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
+androidx-material3-android = { group = "androidx.compose.material3", name = "material3-android", version.ref = "material3Android" }
+ui-tooling-preview-android = { group = "androidx.compose.ui", name = "ui-tooling-preview-android", version.ref = "uiToolingPreviewAndroid" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION

This branch introduces the ability to request location permissions from the user. It includes the following changes:

-   Added `LocationPermissionState` enum to track the permission status.
-   Added `LocationUtils` to check if the app has location permission.
-   Created `CenterLocationPrompt` and `BottomLocationBar` composables to display location prompts to the user.
-   Created `LocationPermissionComponent` to handle the request for the location permission and manage the UI.
- Updated `build.gradle.kts` with new dependencies for compose and material3.
- Added new strings to `strings.xml` and `strings.xml(es)` to support location permission requests and error messages.
- Added `ACCESS_COARSE_LOCATION` and `ACCESS_FINE_LOCATION` permissions to `AndroidManifest.xml`.